### PR TITLE
debian/control: Add Breaks:/Replaces: (qvd-nxproxy): nxproxy.

### DIFF
--- a/nx-libs-3.5.0.22/debian/control
+++ b/nx-libs-3.5.0.22/debian/control
@@ -109,6 +109,8 @@ Description: NX agent
 
 Package: qvd-nxproxy
 Architecture: any
+Breaks: nxproxy,
+Replaces: nxproxy,
 Depends:
  ${shlibs:Depends},
  ${misc:Depends},


### PR DESCRIPTION
QVD's nxproxy shares files with nxproxy, so we needs some Breaks:/Replaces: for qvd-nxproxy.
